### PR TITLE
Fixes to work with H85010d_00.dz

### DIFF
--- a/libexec/dz.py
+++ b/libexec/dz.py
@@ -110,7 +110,8 @@ class DZChunk(DZStruct):
 	# Format string dict
 	#   itemName is the new dict key for the data to be stored under
 	#   formatString is the Python formatstring for struct.unpack()
-	#   collapse is boolean that controls whether extra \x00 's should be stripped
+	#   collapse: boolean that controls whether extra \x00 's should be stripped
+	#             for integer types collapse set to True means that the value should always be zero
 	# Example:
 	#   ('itemName', ('formatString', collapse))
 	_dz_format_dict = OrderedDict([
@@ -146,7 +147,8 @@ class DZFile(DZStruct):
 	# Format string dict
 	#   itemName is the new dict key for the data to be stored under
 	#   formatString is the Python formatstring for struct.unpack()
-	#   collapse is boolean that controls whether extra \x00 's should be stripped
+	#   collapse: boolean that controls whether extra \x00 's should be stripped
+	#             for integer types collapse set to True means that the value should always be zero
 	# Example:
 	#   ('itemName', ('formatString', collapse))
 	_dz_format_dict = OrderedDict([

--- a/libexec/dz.py
+++ b/libexec/dz.py
@@ -123,7 +123,7 @@ class DZChunk(DZStruct):
 		('md5',		('16s',  False)),	# MD5 of target image
 		('targetAddr',	('I',    False)),	# first block to write
 		('trimCount',	('I',    False)),	# blocks to TRIM before
-		('reserved',	('I',    True)),	# currently always zero
+		('reserved',	('I',    False)),	# \x0 or \x1 in H850 FW
 		('crc32',	('I',    False)),	# CRC32 of target image
 		('pad',		('372s', True)),	# currently always zero
 	])
@@ -166,10 +166,11 @@ class DZFile(DZStruct):
 		('unknown2',	('48s',  False)),	# Id? windows thing?
 		('build_type',	('20s',  True)),	# "user"???
 		('unknown3',	('8s',   False)),	# version code?
-		('reserved2',	('I',    True)),	# currently always zero
+		('reserved2',	('I',    False)),	# \x0 or \x31 on H850 FW
 		('reserved3',	('H',    True)),	# padding?
 		('oldDateCode',	('10s',	 True)),	# prior firmware date?
-		('pad',		('180s', True)),	# currently always zero
+		('unknown4',	('6s',   False)),	# all zeroes or \x00\x00\x00\x00\x00\x01 in H850 FW
+		('pad',		('174s', True)),	# currently always zero
 	])
 
 	def __init__(self):

--- a/undz.py
+++ b/undz.py
@@ -25,6 +25,7 @@ import io
 import zlib
 import argparse
 import hashlib
+import re
 from binascii import crc32, b2a_hex
 
 # our tools are in "libexec"
@@ -302,10 +303,11 @@ class UNDZChunk(dz.DZChunk, UNDZUtils):
 		self.crc32	= dz_item['crc32']
 
 		# This is where in the image we're supposed to go
-		targetAddr = int(self.chunkName[len(self.sliceName)+1:-4])
-
-		if targetAddr != self.targetAddr:
-			self.messages.append("[!] Uncompressed starting offset differs from chunk name!")
+		sliceNumeric = re.search('_(\d+)$',self.sliceName)
+		if sliceNumeric is not None:
+			targetAddr = int(sliceNumeric.group(1))
+			if targetAddr != self.targetAddr:
+				self.messages.append("[!] Uncompressed starting offset differs from chunk name!")
 
 
 

--- a/undz.py
+++ b/undz.py
@@ -76,7 +76,7 @@ class UNDZUtils(object):
 					sys.exit(1)
 			elif type(dz_item[key]) is int:
 				if dz_item[key] != 0:
-					print('[!] Error: field "'+key+'" is non-zero ('+b2a_hex(dz_item[key])+')', file=sys.stderr)
+					print('[!] Error: Value supposed to be zero in field "'+key+'" is non-zero ('+hex(dz_item[key])+')', file=sys.stderr)
 					sys.exit(1)
 			else:
 				print("[!] Error: internal error", file=sys.stderr)


### PR DESCRIPTION
Minor fixes that make it possible to extract system.image from H85010d_00.dz firmware. This also closes #5.
